### PR TITLE
Add commandline arguments

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -172,3 +172,9 @@ Storing heartbeat.yaml and the state in the home directory:
 ```
 * * * * * cd /home/me/.heartbeat && /usr/local/bin/python3 heartbeat.py
 ```
+
+Specify a custom configuration and state file:
+
+```
+* * * * * /usr/local/bin/python3 /home/me/heartbeat.py -c /home/me/custom.yaml -s /home/me/.heartbeat.json
+```


### PR DESCRIPTION
Add config file argument (-c/--config)
Add state file argument (-s/--state)

I personally prefer the traditional approach of specifying the custom paths through command line arguments instead of changing the CWD, especially in the case where you want the files to reside in separate locations. In any case, sharing my additions